### PR TITLE
Lookup parameters per content type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -94,3 +94,12 @@ Example:
 Note that this only happens on the client; there is no enforcement of the
 blacklist at the model level.
 
+## Lookup parameters by Content Type
+
+Supply extra lookup parameters per content type simliar to how 
+limit_choices_to works with raw id fields.
+Example:
+
+    class NavBarEntryAdmin(GenericAdminModelAdmin):
+        content_type_lookups = {'app.model': {'field': 'value'}
+

--- a/genericadmin/admin.py
+++ b/genericadmin/admin.py
@@ -14,6 +14,8 @@ class BaseGenericModelAdmin(object):
     class Media:
         js = ()
 
+    content_type_lookups = {}
+    
     def __init__(self, model, admin_site):
         self.grappelli = False
         media = list(self.Media.js)
@@ -37,7 +39,9 @@ class BaseGenericModelAdmin(object):
 
     def get_generic_relation_options(self):
         """ Return a dictionary of keywords that are fed to the get_generic_rel_list view """
-        return {'blacklist':self.get_blacklisted_relations(), 'whitelist':self.get_whitelisted_relations()}
+        return {'url_params': self.content_type_lookups,
+                'blacklist': self.get_blacklisted_relations(),
+                'whitelist': self.get_whitelisted_relations()}
 
     def get_blacklisted_relations(self):
         try:

--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -46,7 +46,7 @@
 
                 if (this.value) {
                     if (that.url_array[this.value]) {
-                        key = that.url_array[this.value].split('/')[0];
+                        key = that.url_array[this.value][0].split('/')[0];
                         // create an array with unique elements
                         if ($.inArray(key, opt_keys) < 0) {
                             opt_keys.push(key);
@@ -77,9 +77,17 @@
             return contentTypeSelect;
         },
 
-
+        getLookupUrlParams: function(cID) {
+            var q = this.url_array[cID][1] || {};
+            var str = [];
+            for(var p in q)
+                str.push(encodeURIComponent(p) + "=" + encodeURIComponent(q[p]));
+            x = str.join("&");
+            url = x ? ("?" + x) : "";
+            return url
+        },
         getLookupUrl: function(cID) {
-            return '../../../' + this.url_array[cID] + '/';
+            return '../../../' + this.url_array[cID][0] + '/' + this.getLookupUrlParams(cID);
         },
         hideLookupLink: function() {
             $('#lookup_' + this.object_input.attr('id')).unbind().remove();

--- a/genericadmin/views.py
+++ b/genericadmin/views.py
@@ -6,7 +6,7 @@ except ImportError:
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.core import serializers
 from django.contrib.contenttypes.models import ContentType
-
+from django.contrib.admin.widgets import url_params_from_lookup_dict
 
 def get_obj(content_type_id, object_id):
     obj_dict = {
@@ -43,17 +43,20 @@ def generic_lookup(request):
     else:
         return HttpResponseNotAllowed(['GET'])
 
-def get_generic_rel_list(request, blacklist=(), whitelist=()):
+def get_generic_rel_list(request, blacklist=(), whitelist=(), url_params={}):
     if request.method == 'GET':
         obj_dict = {}
         for c in ContentType.objects.all().order_by('id'):
             val = u'%s/%s' % (c.app_label, c.model)
+            
+            params = url_params.get('%s.%s' % (c.app_label, c.model), {})
+            params = url_params_from_lookup_dict(params)
             if whitelist:
                 if val in whitelist:
-                    obj_dict[c.id] = val
+                    obj_dict[c.id] = (val, params)
             else:
                 if val not in blacklist:
-                    obj_dict[c.id] = val
+                    obj_dict[c.id] = (val, params)
 
         response = HttpResponse(mimetype='application/json')
         json.dump(obj_dict, response, ensure_ascii=False)


### PR DESCRIPTION
This, like blacklisting/whitelisting, is only enforced on the frontend and not on the python level
