### PR TITLE
Fixed the bug that broke the simple examples.

### DIFF
--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -4,6 +4,8 @@
     updated by Jan Schrewe (jschrewe@googlemail.com)
 
     updated by Troy Melhase (troy.melhase@gmail.com)
+    
+	updated by Jonathan Ellenberger (jon@respondcreate.com)
 
  */
  (function($) {


### PR DESCRIPTION
The forloop now checks the length of vars. If it's not equal to 1 it enters the forloop. If it is equal to 1 it skips the forloop entirely.
