### PR TITLE
Fixed broken path to admin selector image

### DIFF
--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -110,7 +110,7 @@
             var id = 'lookup_' + this_id;
 
             var link = '<a class="related-lookup" id="' + id + '" href="' + url + '">';
-            link = link + '<img src="' + this.admin_media_url + 'img/admin/selector-search.gif" style="cursor: pointer; margin-left: 5px; margin-right: 10px;" width="16" height="16" alt="Lookup"></a>';
+            link = link + '<img src="' + this.admin_media_url + 'img/selector-search.gif" style="cursor: pointer; margin-left: 5px; margin-right: 10px;" width="16" height="16" alt="Lookup"></a>';
             link = link + '<strong id="lookup_text_'+ this_id +'" margin-left: 5px"></strong>';
 
             // insert link html after input element


### PR DESCRIPTION
With 1.3's django.contrib.staticfiles, after a run of `collect static` static assets are copied to the more conventional location of `{{ STATIC_URL }}admin/img/selector-search.gif`. This patch fixes it for now, but the ADMIN_MEDIA_URL prefix is deprecated in the upcoming 1.4. This should be rewritten with STATIC_URL soon.
