### PR TITLE
Specifying only css in your admin doesn't work

### DIFF
--- a/genericadmin/admin.py
+++ b/genericadmin/admin.py
@@ -15,7 +15,10 @@ class BaseGenericModelAdmin(object):
     
     def __init__(self, model, admin_site):
         self.grappelli = False
-        media = list(self.Media.js)
+        try:
+            media = list(self.Media.js)
+        except:
+            media = []
         #if 'grappelli' in settings.INSTALLED_APPS:
         #    media.append(JS_PATH + 'genericadmin-grappelli.js')
         #    self.grappelli = True


### PR DESCRIPTION
This patch fixes a problem that specifying only the css in the admin didn't work, for example.

``` python
class MyAdmin(GenericAdminModelAdmin):
    class Media:
        css = {
            "all": ("myadmin.css",)
        }
```

Because in this case self.Media.js doesn't exist.
