### PR TITLE
Fix add inline on Django 1.6

### DIFF
--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -14,7 +14,7 @@
         fields: null,
         obj_url: "../obj-data/",
         admin_media_url: window.__admin_media_prefix__,
-		popup: 'pop',
+		popup: '_popup',
         
         prepareSelect: function(select) {
             var that = this,
@@ -273,7 +273,7 @@
                 var added_fields = $.extend({}, that.fields),
                     admin = $.extend({}, GenericAdmin);
                 added_fields.number = ($('#id_' + that.fields.prefix + '-TOTAL_FORMS').val() - 1);
-                admin.install(added_fields, that.url_array);
+                admin.install(added_fields, that.url_array, admin.popup);
                 that.sub_admins.push(admin);
                 
                 $('#' + that.fields.prefix + '-' + added_fields.number + ' .inline-deletelink').click(


### PR DESCRIPTION
Last item: installing the genericadmin on added inlines used the wrong name and hadn't been updated for the new variable.
