### PR TITLE
[-] Explicit admin urls lookup

### DIFF
--- a/genericadmin/admin.py
+++ b/genericadmin/admin.py
@@ -106,9 +106,9 @@ class BaseGenericModelAdmin(object):
 
                 if self.content_type_whitelist:
                     if val in self.content_type_whitelist:
-                        obj_dict[c.id] = (url, params)
+                        obj_dict[c.id] = (val, url, params)
                 elif val not in self.content_type_blacklist:
-                    obj_dict[c.id] = (url, params)
+                    obj_dict[c.id] = (val, url, params)
 
             data = {
                 'url_array': obj_dict,

--- a/genericadmin/admin.py
+++ b/genericadmin/admin.py
@@ -1,8 +1,7 @@
 import json
 from functools import update_wrapper
 
-from django.core.urlresolvers import reverse
-from django.core.exceptions import NoReverseMatch
+from django.core.urlresolvers import reverse, NoReverseMatch
 from django.contrib import admin
 from django.conf.urls import patterns, url
 from django.conf import settings

--- a/genericadmin/admin.py
+++ b/genericadmin/admin.py
@@ -100,7 +100,7 @@ class BaseGenericModelAdmin(object):
                 try:
                     # Reverse the admin changelist url
                     url = reverse('admin:%s_%s_changelist' % (
-                        c.app_label, c.model), kwargs=params)
+                        c.app_label, c.model))
                 except (NoReverseMatch, ):
                     continue
 

--- a/genericadmin/admin.py
+++ b/genericadmin/admin.py
@@ -1,13 +1,15 @@
 import json
 from functools import update_wrapper
 
+from django.core.urlresolvers import reverse
+from django.core.exceptions import NoReverseMatch
 from django.contrib import admin
 from django.conf.urls import patterns, url
 from django.conf import settings
 from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
 try:
-    from django.utils.encoding import force_text 
+    from django.utils.encoding import force_text
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 from django.utils.text import capfirst
@@ -19,7 +21,7 @@ except ImportError:
     from django.contrib.admin.options import IS_POPUP_VAR
 from  django.core.exceptions import ObjectDoesNotExist
 
-JS_PATH = getattr(settings, 'GENERICADMIN_JS', 'genericadmin/js/') 
+JS_PATH = getattr(settings, 'GENERICADMIN_JS', 'genericadmin/js/')
 
 class BaseGenericModelAdmin(object):
     class Media:
@@ -29,7 +31,7 @@ class BaseGenericModelAdmin(object):
     generic_fk_fields = []
     content_type_blacklist = []
     content_type_whitelist = []
-    
+
     def __init__(self, model, admin_site):
         try:
             media = list(self.Media.js)
@@ -37,10 +39,10 @@ class BaseGenericModelAdmin(object):
             media = []
         media.append(JS_PATH + 'genericadmin.js')
         self.Media.js = tuple(media)
-        
+
         self.content_type_whitelist = [s.lower() for s in self.content_type_whitelist]
-        self.content_type_blacklist = [s.lower() for s in self.content_type_blacklist]        
-            
+        self.content_type_blacklist = [s.lower() for s in self.content_type_blacklist]
+
         super(BaseGenericModelAdmin, self).__init__(model, admin_site)
 
     def get_generic_field_list(self, request, prefix=''):
@@ -48,7 +50,7 @@ class BaseGenericModelAdmin(object):
             exclude = [self.ct_field, self.ct_fk_field]
         else:
             exclude = []
-        
+
         field_list = []
         if hasattr(self, 'generic_fk_fields') and self.generic_fk_fields:
             for fields in self.generic_fk_fields:
@@ -57,17 +59,17 @@ class BaseGenericModelAdmin(object):
                     fields['inline'] = prefix != ''
                     fields['prefix'] = prefix
                     field_list.append(fields)
-        else:    
+        else:
             for field in self.model._meta.virtual_fields:
                 if isinstance(field, generic.GenericForeignKey) and \
                         field.ct_field not in exclude and field.fk_field not in exclude:
                     field_list.append({
-                        'ct_field': field.ct_field, 
+                        'ct_field': field.ct_field,
                         'fk_field': field.fk_field,
                         'inline': prefix != '',
                         'prefix': prefix,
                     })
-                    
+
         if hasattr(self, 'inlines') and len(self.inlines) > 0:
             for FormSet, inline in zip(self.get_formsets(request), self.get_inline_instances(request)):
                 if hasattr(inline, 'get_generic_field_list'):
@@ -81,13 +83,13 @@ class BaseGenericModelAdmin(object):
             def wrapper(*args, **kwargs):
                 return self.admin_site.admin_view(view)(*args, **kwargs)
             return update_wrapper(wrapper, view)
-        
+
         custom_urls = patterns('',
             url(r'^obj-data/$', wrap(self.generic_lookup), name='admin_genericadmin_obj_lookup'),
             url(r'^genericadmin-init/$', wrap(self.genericadmin_js_init), name='admin_genericadmin_init'),
         )
         return custom_urls + super(BaseGenericModelAdmin, self).get_urls()
-            
+
     def genericadmin_js_init(self, request):
         if request.method == 'GET':
             obj_dict = {}
@@ -95,12 +97,20 @@ class BaseGenericModelAdmin(object):
                 val = force_text('%s/%s' % (c.app_label, c.model))
                 params = self.content_type_lookups.get('%s.%s' % (c.app_label, c.model), {})
                 params = url_params_from_lookup_dict(params)
+
+                try:
+                    # Reverse the admin changelist url
+                    url = reverse('admin:%s_%s_changelist' % (
+                        c.app_label, c.model), kwargs=params)
+                except (NoReverseMatch, ):
+                    continue
+
                 if self.content_type_whitelist:
                     if val in self.content_type_whitelist:
-                        obj_dict[c.id] = (val, params)
+                        obj_dict[c.id] = (url, params)
                 elif val not in self.content_type_blacklist:
-                    obj_dict[c.id] = (val, params)
-        
+                    obj_dict[c.id] = (url, params)
+
             data = {
                 'url_array': obj_dict,
                 'fields': self.get_generic_field_list(request),
@@ -109,15 +119,15 @@ class BaseGenericModelAdmin(object):
             resp = json.dumps(data, ensure_ascii=False)
             return HttpResponse(resp, content_type='application/json')
         return HttpResponseNotAllowed(['GET'])
-    
+
     def generic_lookup(self, request):
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        
+
         if 'content_type' in request.GET and 'object_id' in request.GET:
             content_type_id = request.GET['content_type']
             object_id = request.GET['object_id']
-            
+
             obj_dict = {
                 'content_type_id': content_type_id,
                 'object_id': object_id,
@@ -131,12 +141,12 @@ class BaseGenericModelAdmin(object):
                 obj_dict["object_text"] = capfirst(force_text(obj))
             except ObjectDoesNotExist:
                 raise Http404
-            
+
             resp = json.dumps(obj_dict, ensure_ascii=False)
         else:
             resp = ''
         return HttpResponse(resp, content_type='application/json')
-        
+
 
 
 class GenericAdminModelAdmin(BaseGenericModelAdmin, admin.ModelAdmin):
@@ -144,7 +154,7 @@ class GenericAdminModelAdmin(BaseGenericModelAdmin, admin.ModelAdmin):
 
 
 class GenericTabularInline(BaseGenericModelAdmin, generic.GenericTabularInline):
-    """Model admin for generic tabular inlines. """ 
+    """Model admin for generic tabular inlines. """
 
 
 class GenericStackedInline(BaseGenericModelAdmin, generic.GenericStackedInline):

--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -62,7 +62,7 @@
         },
 
         getLookupUrlParams: function(cID) {
-            var q = this.url_array[cID][1] || {},
+            var q = this.url_array[cID][2] || {},
                 str = [];
             for(var p in q) {
                 str.push(encodeURIComponent(p) + "=" + encodeURIComponent(q[p]));
@@ -73,7 +73,7 @@
         },
 
         getLookupUrl: function(cID) {
-            return this.url_array[cID][0] + this.getLookupUrlParams(cID);
+            return this.url_array[cID][1] + this.getLookupUrlParams(cID);
         },
 
         getFkId: function() {

--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -15,7 +15,7 @@
         obj_url: "../obj-data/",
         admin_media_url: window.__admin_media_prefix__,
 		popup: '_popup',
-        
+
         prepareSelect: function(select) {
             var that = this,
                 opt_keys = [],
@@ -30,7 +30,7 @@
                 if (this.value) {
                     if (that.url_array[this.value]) {
                         key = that.url_array[this.value][0].split('/')[0];
-                        
+
                         opt = $(this).clone();
                         opt.text(that.capFirst(opt.text()));
                         if ($.inArray(key, opt_keys) < 0) {
@@ -47,7 +47,7 @@
                 }
             });
             select.empty().append(no_value);
-            
+
             opt_keys = opt_keys.sort();
 
             $.each(opt_keys, function(index, key) {
@@ -62,7 +62,7 @@
         },
 
         getLookupUrlParams: function(cID) {
-            var q = this.url_array[cID][1] || {}, 
+            var q = this.url_array[cID][1] || {},
                 str = [];
             for(var p in q) {
                 str.push(encodeURIComponent(p) + "=" + encodeURIComponent(q[p]));
@@ -71,11 +71,11 @@
             url = x ? ("?" + x) : "";
             return url;
         },
-        
+
         getLookupUrl: function(cID) {
-            return '../../../' + this.url_array[cID][0] + '/' + this.getLookupUrlParams(cID);
+            return this.url_array[cID][0] + '/' + this.getLookupUrlParams(cID);
         },
-        
+
         getFkId: function() {
             if (this.fields.inline === false) {
                 return 'id_' + this.fields.fk_field;
@@ -83,7 +83,7 @@
                 return ['id_', this.fields.prefix, '-', this.fields.number, '-', this.fields.fk_field].join('');
             }
         },
-        
+
         getCtId: function() {
             if (this.fields.inline === false) {
                 return 'id_' + this.fields.ct_field;
@@ -91,24 +91,24 @@
                 return ['id_', this.fields.prefix, '-', this.fields.number, '-', this.fields.ct_field].join('');
             }
         },
-        
+
         capFirst: function(string) {
             return string.charAt(0).toUpperCase() + string.slice(1);
         },
-        
+
         hideLookupLink: function() {
             var this_id = this.getFkId();
             $('#lookup_' + this_id).unbind().remove();
             $('#lookup_text_' + this_id + ' a').remove();
             $('#lookup_text_' + this_id + ' span').remove();
         },
-        
+
         showLookupLink: function() {
             var that = this,
                 url = this.getLookupUrl(this.cID),
                 id = 'lookup_' + this.getFkId(),
                 link = '<a class="related-lookup" id="' + id + '" href="' + url + '">';
-                
+
             link = link + '<img src="' + this.admin_media_url.replace(/\/?$/, '/') + 'img/selector-search.gif" style="cursor: pointer; margin-left: 5px; margin-right: 10px;" width="16" height="16" alt="Lookup"></a>';
             link = link + '<strong id="lookup_text_'+ this.getFkId() +'" margin-left: 5px"><a target="_new" href="#"></a><span></span></strong>';
 
@@ -117,7 +117,7 @@
 
             return id;
         },
-        
+
         pollInputChange: function(window) {
             var that = this,
                 interval_id = setInterval(function() {
@@ -129,11 +129,11 @@
                 },
                 150);
         },
-        
+
         popRelatedObjectLookup: function(link) {
             var name = id_to_windowname(this.getFkId()),
 				url_parts = [],
-                href, 
+                href,
                 win;
 
             if (link.href.search(/\?/) >= 0) {
@@ -154,14 +154,14 @@
             win.focus();
             return false;
         },
-        
+
         updateObjectData: function() {
             var that = this;
             return function() {
                 var value = that.object_input.val();
-                
-                if (!value) { 
-                    return 
+
+                if (!value) {
+                    return
                 }
                 //var this_id = that.getFkId();
                 $('#lookup_text_' + that.getFkId() + ' span').text('loading...');
@@ -206,10 +206,10 @@
             this.url_array = url_array;
             this.fields = fields;
 			this.popup = popup_var || this.popup;
-            
+
             // store the base element
             this.object_input = $("#" + this.getFkId());
-            
+
             // find the select we need to change
             this.object_select = this.prepareSelect($("#" + this.getCtId()));
 
@@ -243,22 +243,22 @@
             this.updateObjectData()();
         }
     };
-    
+
     var InlineAdmin = {
         sub_admins: null,
         url_array: null,
         fields: null,
 		popup: '_popup',
-        
+
         install: function(fields, url_array, popup_var) {
             var inline_count = $('#id_' + fields.prefix + '-TOTAL_FORMS').val(),
                 admin;
-            
+
             this.url_array = url_array;
             this.fields = fields;
             this.sub_admins = [];
 			this.popup = popup_var || this.popup;
-            
+
             for (var j = 0; j < inline_count; j++) {
                 f = $.extend({}, this.fields);
                 f.number = j;
@@ -277,7 +277,7 @@
                 added_fields.number = ($('#id_' + that.fields.prefix + '-TOTAL_FORMS').val() - 1);
                 admin.install(added_fields, that.url_array, that.popup);
                 that.sub_admins.push(admin);
-                
+
                 $('#' + that.fields.prefix + '-' + added_fields.number + ' .inline-deletelink').click(
                     that.removeHandler(that)
                 );
@@ -288,7 +288,7 @@
                 var parent_id,
                     deleted_num,
                     sub_admin;
-                
+
                 e.preventDefault();
                 parent_id = $(e.currentTarget).parents('.dynamic-' + that.fields.prefix).first().attr('id');
                 deleted_num = parseInt(parent_id.charAt(parent_id.length - 1), 10);
@@ -313,7 +313,7 @@
                     ct_fields = data.fields,
 					popup_var = data.popup_var,
                     fields;
-                    
+
                 for (var i = 0; i < ct_fields.length; i++) {
                     fields = ct_fields[i];
                     if (fields.inline === false) {

--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -73,7 +73,7 @@
         },
 
         getLookupUrl: function(cID) {
-            return this.url_array[cID][0] + '/' + this.getLookupUrlParams(cID);
+            return this.url_array[cID][0] + this.getLookupUrlParams(cID);
         },
 
         getFkId: function() {

--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -72,7 +72,8 @@
             return url;
         },
 
-        getLookupUrl: function(cID, params=true) {
+        getLookupUrl: function(cID, params) {
+            params = params || true;
             url = this.url_array[cID][1];
             if(params){url + this.getLookupUrlParams(cID);}
             return url;

--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -72,8 +72,10 @@
             return url;
         },
 
-        getLookupUrl: function(cID) {
-            return this.url_array[cID][1] + this.getLookupUrlParams(cID);
+        getLookupUrl: function(cID, params=true) {
+            url = this.url_array[cID][1];
+            if(params){url + this.getLookupUrlParams(cID);}
+            return url;
         },
 
         getFkId: function() {
@@ -105,7 +107,7 @@
 
         showLookupLink: function() {
             var that = this,
-                url = this.getLookupUrl(this.cID),
+                url = this.getLookupUrl(this.cID, false),
                 id = 'lookup_' + this.getFkId(),
                 link = '<a class="related-lookup" id="' + id + '" href="' + url + '">';
 

--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -72,10 +72,9 @@
             return url;
         },
 
-        getLookupUrl: function(cID, params) {
-            params = params || true;
-            url = this.url_array[cID][1];
-            if(params){url + this.getLookupUrlParams(cID);}
+        getLookupUrl: function(cID, with_params) {
+            var url = this.url_array[cID][1];
+            if(with_params){url = url + this.getLookupUrlParams(cID);}
             return url;
         },
 
@@ -108,7 +107,7 @@
 
         showLookupLink: function() {
             var that = this,
-                url = this.getLookupUrl(this.cID, false),
+                url = this.getLookupUrl(this.cID, true),
                 id = 'lookup_' + this.getFkId(),
                 link = '<a class="related-lookup" id="' + id + '" href="' + url + '">';
 
@@ -177,7 +176,7 @@
                     },
                     success: function(item) {
                         if (item && item.content_type_text && item.object_text) {
-                            var url = that.getLookupUrl(that.cID);
+                            var url = that.getLookupUrl(that.cID, false);
                             $('#lookup_text_' + that.getFkId() + ' a')
                                 .text(item.content_type_text + ': ' + item.object_text)
                                 .attr('href', url + item.object_id);


### PR DESCRIPTION
The code here reveres the admin urls, ensuring the urls are accessable. The json object return includes a new tuple `(val, url, params)`, was `(val, params)`

The reason for these changes besides making it more explicit, is we had a case working with django-cms and editing a field via its front-end-editing modal, the url was added by django-cms onto out content type, this created `/admin/content/article/edit-field/` available, for example. However genericadmin didnt register its urls with `/admin/content/article/edit-field..` this made genericadmin 404 or sometimes 500 because django-cms `edit-field` view was matched and expected parameters that was not supplied.

We resolve this issue by overriding `get_urls`, but this still left us with a 404 when clicking the magnifying glass because of the hard coded javascript that had `../../../` when building the urls.

Perhaps we can adapt generic admin to apply its urls to what ever `get_urls` returns. Either way here is our custom django-cms specific `get_urls` we used in combination with this PR

``` python

        # Taken from `genericadmin.admin.py`
        def wrap(view):
            def wrapper(*args, **kwargs):
                return self.admin_site.admin_view(view)(*args, **kwargs)
            return update_wrapper(wrapper, view)

        # The patched views name and args we add to generic admin, add
        # more here as needed
        patched_views = (('edit-field', '\d+'), )

        urls = []
        for view, args in patched_views:
            # Generic admin obj lookup
            urls.append(
                url(r'^{}/{}/obj-data/$'.format(view, args), wrap(
                    self.generic_lookup),
                    name='admin_{}_genericadmin_obj_lookup'.format(view)))
            # Generic admin init
            urls.append(
                url(r'^{}/{}/genericadmin-init/$'.format(view, args), wrap(
                    self.genericadmin_js_init),
                    name='admin_{}_genericadmin_init'.format(view)))

        new_urls = patterns('', *urls)
```

_ps. my editor eats white-space_
