### PR TITLE
Remove 'related-lookup' from inserted link

### DIFF
--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -107,7 +107,7 @@
             var that = this,
                 url = this.getLookupUrl(this.cID),
                 id = 'lookup_' + this.getFkId(),
-                link = '<a class="related-lookup" id="' + id + '" href="' + url + '">';
+                link = '<a style="margin-right: 10px;" id="' + id + '" href="' + url + '">';
                 
             link = link + '<img src="' + this.admin_media_url.replace(/\/?$/, '/') + 'img/selector-search.gif" style="cursor: pointer; margin-left: 5px; margin-right: 10px;" width="16" height="16" alt="Lookup"></a>';
             link = link + '<strong id="lookup_text_'+ this.getFkId() +'" margin-left: 5px"><a target="_new" href="#"></a><span></span></strong>';


### PR DESCRIPTION
...because its background image duplicates its child image, and add 10px of right margin to it to space things out.

Part of #27.
