### PR TITLE
Removing `class="related-lookup"`

### DIFF
--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -15,7 +15,7 @@
         obj_url: "../obj-data/",
         admin_media_url: window.__admin_media_prefix__,
 		popup: '_popup',
-        
+
         prepareSelect: function(select) {
             var that = this,
                 opt_keys = [],
@@ -30,7 +30,7 @@
                 if (this.value) {
                     if (that.url_array[this.value]) {
                         key = that.url_array[this.value][0].split('/')[0];
-                        
+
                         opt = $(this).clone();
                         opt.text(that.capFirst(opt.text()));
                         if ($.inArray(key, opt_keys) < 0) {
@@ -47,7 +47,7 @@
                 }
             });
             select.empty().append(no_value);
-            
+
             opt_keys = opt_keys.sort();
 
             $.each(opt_keys, function(index, key) {
@@ -62,7 +62,7 @@
         },
 
         getLookupUrlParams: function(cID) {
-            var q = this.url_array[cID][1] || {}, 
+            var q = this.url_array[cID][1] || {},
                 str = [];
             for(var p in q) {
                 str.push(encodeURIComponent(p) + "=" + encodeURIComponent(q[p]));
@@ -71,11 +71,11 @@
             url = x ? ("?" + x) : "";
             return url;
         },
-        
+
         getLookupUrl: function(cID) {
             return '../../../' + this.url_array[cID][0] + '/' + this.getLookupUrlParams(cID);
         },
-        
+
         getFkId: function() {
             if (this.fields.inline === false) {
                 return 'id_' + this.fields.fk_field;
@@ -83,7 +83,7 @@
                 return ['id_', this.fields.prefix, '-', this.fields.number, '-', this.fields.fk_field].join('');
             }
         },
-        
+
         getCtId: function() {
             if (this.fields.inline === false) {
                 return 'id_' + this.fields.ct_field;
@@ -91,24 +91,24 @@
                 return ['id_', this.fields.prefix, '-', this.fields.number, '-', this.fields.ct_field].join('');
             }
         },
-        
+
         capFirst: function(string) {
             return string.charAt(0).toUpperCase() + string.slice(1);
         },
-        
+
         hideLookupLink: function() {
             var this_id = this.getFkId();
             $('#lookup_' + this_id).unbind().remove();
             $('#lookup_text_' + this_id + ' a').remove();
             $('#lookup_text_' + this_id + ' span').remove();
         },
-        
+
         showLookupLink: function() {
             var that = this,
                 url = this.getLookupUrl(this.cID),
                 id = 'lookup_' + this.getFkId(),
-                link = '<a class="related-lookup" id="' + id + '" href="' + url + '">';
-                
+                link = '<a id="' + id + '" href="' + url + '">';
+
             link = link + '<img src="' + this.admin_media_url.replace(/\/?$/, '/') + 'img/selector-search.gif" style="cursor: pointer; margin-left: 5px; margin-right: 10px;" width="16" height="16" alt="Lookup"></a>';
             link = link + '<strong id="lookup_text_'+ this.getFkId() +'" margin-left: 5px"><a target="_new" href="#"></a><span></span></strong>';
 
@@ -117,7 +117,7 @@
 
             return id;
         },
-        
+
         pollInputChange: function(window) {
             var that = this,
                 interval_id = setInterval(function() {
@@ -129,11 +129,11 @@
                 },
                 150);
         },
-        
+
         popRelatedObjectLookup: function(link) {
             var name = id_to_windowname(this.getFkId()),
 				url_parts = [],
-                href, 
+                href,
                 win;
 
             if (link.href.search(/\?/) >= 0) {
@@ -154,14 +154,14 @@
             win.focus();
             return false;
         },
-        
+
         updateObjectData: function() {
             var that = this;
             return function() {
                 var value = that.object_input.val();
-                
-                if (!value) { 
-                    return 
+
+                if (!value) {
+                    return
                 }
                 //var this_id = that.getFkId();
                 $('#lookup_text_' + that.getFkId() + ' span').text('loading...');
@@ -206,10 +206,10 @@
             this.url_array = url_array;
             this.fields = fields;
 			this.popup = popup_var || this.popup;
-            
+
             // store the base element
             this.object_input = $("#" + this.getFkId());
-            
+
             // find the select we need to change
             this.object_select = this.prepareSelect($("#" + this.getCtId()));
 
@@ -243,22 +243,22 @@
             this.updateObjectData()();
         }
     };
-    
+
     var InlineAdmin = {
         sub_admins: null,
         url_array: null,
         fields: null,
 		popup: '_popup',
-        
+
         install: function(fields, url_array, popup_var) {
             var inline_count = $('#id_' + fields.prefix + '-TOTAL_FORMS').val(),
                 admin;
-            
+
             this.url_array = url_array;
             this.fields = fields;
             this.sub_admins = [];
 			this.popup = popup_var || this.popup;
-            
+
             for (var j = 0; j < inline_count; j++) {
                 f = $.extend({}, this.fields);
                 f.number = j;
@@ -277,7 +277,7 @@
                 added_fields.number = ($('#id_' + that.fields.prefix + '-TOTAL_FORMS').val() - 1);
                 admin.install(added_fields, that.url_array, that.popup);
                 that.sub_admins.push(admin);
-                
+
                 $('#' + that.fields.prefix + '-' + added_fields.number + ' .inline-deletelink').click(
                     that.removeHandler(that)
                 );
@@ -288,7 +288,7 @@
                 var parent_id,
                     deleted_num,
                     sub_admin;
-                
+
                 e.preventDefault();
                 parent_id = $(e.currentTarget).parents('.dynamic-' + that.fields.prefix).first().attr('id');
                 deleted_num = parseInt(parent_id.charAt(parent_id.length - 1), 10);
@@ -313,7 +313,7 @@
                     ct_fields = data.fields,
 					popup_var = data.popup_var,
                     fields;
-                    
+
                 for (var i = 0; i < ct_fields.length; i++) {
                     fields = ct_fields[i];
                     if (fields.inline === false) {


### PR DESCRIPTION
Having the class `related-lookup` on the link element added in `showLookupLink` results in some visual weirdness:

![image](https://cloud.githubusercontent.com/assets/1625749/18212662/63d252d4-7112-11e6-8146-f0bb03cc4144.png)

Removing this class results in something less strange-looking:

![image](https://cloud.githubusercontent.com/assets/1625749/18212679/784c495e-7112-11e6-8360-236b8268e21d.png)
