### PR TITLE
Add trailing slash to looked up link

### DIFF
--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -179,7 +179,7 @@
                             var url = that.getLookupUrl(that.cID);
                             $('#lookup_text_' + that.getFkId() + ' a')
                                 .text(item.content_type_text + ': ' + item.object_text)
-                                .attr('href', url + item.object_id);
+                                .attr('href', url + item.object_id + '/');
 
                             // run a callback to do other stuff like prepopulating url fields
                             // can't be done with normal django admin prepopulate


### PR DESCRIPTION
Hi arthanson,

genericadmin.js creates the link to the object without a trailing slash, wich is fine as long as APPEND_SLASH is unset or True in settings.py. We do now have the case, that this is not enabled, and as a result the links to objects became unusable.

It's just a minimal fix, that is okay with our project and might help other people as well. But more generally I think genericadmin.js:108 does not handle the case correctly when getLookupUrlParams returns a nonempty string.